### PR TITLE
Add (Name#Discriminator) to farewell messages for mobile users and deleted users

### DIFF
--- a/app.py
+++ b/app.py
@@ -20,7 +20,7 @@ async def on_ready():
 
 async def on_member_event(member, file):
     channel = member.guild.get_channel(int(config['GROOVE']['general_channel_id']))
-    response = random.choice(await read_file(file, as_array=True)).format(member.mention)
+    response = random.choice(await read_file(file, as_array=True)).format(member.mention,member.name,member.discriminator)
     await channel.send(response)
 
 

--- a/resources/farewells.txt
+++ b/resources/farewells.txt
@@ -1,11 +1,11 @@
-{0} escaped the Heavy Light Temple.
-{0} was really un-curving my acoustics, he gone now.
-{0} was chased away by pogo sticks.
-{0} had trouble with lazers apparently.
-{0} was vaporized by lazers.
-I guess {0} was never informed that Animusic 3 is still being worked on.
-{0} left the moment animusic 3 was released, looks like he will never get to see it.
-I guess {0} is not an Animusic fan.
-{0} was peeing ANIMUSIC, then left. :(
-{0} saw Denyul abusing the announcement channel and did not take it too well.
-{0} lost their spine to the Sticks.
+{0} ({1}#{2}) escaped the Heavy Light Temple.
+{0} ({1}#{2}) was really un-curving my acoustics, he gone now.
+{0} ({1}#{2}) was chased away by pogo sticks.
+{0} ({1}#{2}) had trouble with lazers apparently.
+{0} ({1}#{2}) was vaporized by lazers.
+I guess {0} ({1}#{2}) was never informed that Animusic 3 is still being worked on.
+{0} ({1}#{2}) left the moment animusic 3 was released, looks like he will never get to see it.
+I guess {0} ({1}#{2}) is not an Animusic fan.
+{0} ({1}#{2}) was peeing ANIMUSIC, then left. :(
+{0} ({1}#{2}) saw Denyul abusing the announcement channel and did not take it too well.
+{0} ({1}#{2}) lost their spine to the Sticks.


### PR DESCRIPTION
This pull request adds additional context to farewell messages for mobile users who just see @invalid-name, or when a deleted user leaves the server.