### PR TITLE
Reimplement rainbow command on .neuropol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 venv
 __pycache__
 **/__pycache__
+.vscode/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.formatting.provider": "black"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.formatting.provider": "black"
+}

--- a/groovebot/core/cogs.py
+++ b/groovebot/core/cogs.py
@@ -113,7 +113,7 @@ class AbbreviationCog(commands.Cog):
 class MiscCog(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
-    
+
     def _map_range(self, value, inMin, inMax, outMin, outMax):
         return outMin + (((value - inMin) / (inMax - inMin)) * (outMax - outMin))
 
@@ -127,17 +127,28 @@ class MiscCog(commands.Cog):
 
     async def _text_to_neuropol(self, message, color):
         font = ImageFont.truetype("./resources/NEUROPOL.ttf", 35)
-        img = Image.new("RGBA", (font.getsize(message)[0] + 20, 40), (255, 0, 0, 0))  # x coord gets bounding box of text + 20px margin
+        img = Image.new(
+            "RGBA", (font.getsize(message)[0] + 20, 40), (255, 0, 0, 0)
+        )  # x coord gets bounding box of text + 20px margin
         if color == "#rainbow":
             sp = 0
             rgb_vals = []
             for i in range(len(message)):
                 map_range = self._map_range(i, 0, len(message), 0, 1)
-                rgb_vals.append(tuple(round(map_range * 255) for map_range in hsv_to_rgb(map_range,1,1)))
-                ImageDraw.Draw(img).text((10 + sp, 0), text=message[i], fill=rgb_vals[i], font=font)
+                rgb_vals.append(
+                    tuple(
+                        round(map_range * 255)
+                        for map_range in hsv_to_rgb(map_range, 1, 1)
+                    )
+                )
+                ImageDraw.Draw(img).text(
+                    (10 + sp, 0), text=message[i], fill=rgb_vals[i], font=font
+                )
                 sp += font.getsize(message[i])[0]
         else:
-            ImageDraw.Draw(img).text((10, 0), message, fill=color if color else "#fff", font=font)  # x = 10 to center
+            ImageDraw.Draw(img).text(
+                (10, 0), message, fill=color if color else "#fff", font=font
+            )  # x = 10 to center
         await asyncio.get_running_loop().run_in_executor(
             None, img.save, f"{message}.png"
         )
@@ -147,7 +158,8 @@ class MiscCog(commands.Cog):
     async def neuropol(self, ctx, *args):
         color = (
             args[-1]
-            if re.search("^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$", args[-1]) or args[-1] == "#rainbow"
+            if re.search("^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$", args[-1])
+            or args[-1] == "#rainbow"
             else None
         )
         message = " ".join(args[:-1] if color else args).upper()

--- a/groovebot/core/cogs.py
+++ b/groovebot/core/cogs.py
@@ -1,7 +1,7 @@
 import asyncio
 import random
 import re
-import colorsys
+from colorsys import hsv_to_rgb
 
 import aiofiles.os
 import discord
@@ -113,6 +113,9 @@ class AbbreviationCog(commands.Cog):
 class MiscCog(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
+    
+    def _map_range(self, value, inMin, inMax, outMin, outMax):
+        return outMin + (((value - inMin) / (inMax - inMin)) * (outMax - outMin))
 
     @commands.command()
     async def fact(self, ctx):
@@ -124,12 +127,17 @@ class MiscCog(commands.Cog):
 
     async def _text_to_neuropol(self, message, color):
         font = ImageFont.truetype("./resources/NEUROPOL.ttf", 35)
-        img = Image.new(
-            "RGBA", (font.getsize(message)[0] + 20, 40), (255, 0, 0, 0)
-        )  # x coord gets bounding box of text + 20px margin
-        ImageDraw.Draw(img).text(
-            (10, 0), message, fill=color if color else "#fff", font=font
-        )  # x = 10 to center
+        img = Image.new("RGBA", (font.getsize(message)[0] + 20, 40), (255, 0, 0, 0))  # x coord gets bounding box of text + 20px margin
+        if color == "#rainbow":
+            sp = 0
+            rgb_vals = []
+            for i in range(len(message)):
+                map_range = self._map_range(i, 0, len(message), 0, 1)
+                rgb_vals.append(tuple(round(map_range * 255) for map_range in hsv_to_rgb(map_range,1,1)))
+                ImageDraw.Draw(img).text((10 + sp, 0), text=message[i], fill=rgb_vals[i], font=font)
+                sp += font.getsize(message[i])[0]
+        else:
+            ImageDraw.Draw(img).text((10, 0), message, fill=color if color else "#fff", font=font)  # x = 10 to center
         await asyncio.get_running_loop().run_in_executor(
             None, img.save, f"{message}.png"
         )
@@ -139,7 +147,7 @@ class MiscCog(commands.Cog):
     async def neuropol(self, ctx, *args):
         color = (
             args[-1]
-            if re.search("^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$", args[-1])
+            if re.search("^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$", args[-1]) or args[-1] == "#rainbow"
             else None
         )
         message = " ".join(args[:-1] if color else args).upper()

--- a/resources/help.txt
+++ b/resources/help.txt
@@ -3,7 +3,7 @@ Hello! I am GrooveBot, a bot specially created for the r/Animusic Discord server
 If you have any issues/requests contact a Groovebot developer.
 >>> ~~---------------~~:tools: Commands :tools:~~----------------~~
 **fact** - Retrieves an Animusic fact.
-**neuropol** `[message]` - Parses message into neuropol font. Put a hexcode at the end of your message to apply color.
+**neuropol** `[message]` - Parses message into neuropol font. Put a hexcode or `rainbow` at the end of your message to apply color.
 **getalbums** - Retrieves all albums.
 **getabbreviations** - Retrieves all abbreviations.
 **get** `[acronym]` - Retrieves data via acronym.

--- a/resources/help.txt
+++ b/resources/help.txt
@@ -3,7 +3,7 @@ Hello! I am GrooveBot, a bot specially created for the r/Animusic Discord server
 If you have any issues/requests contact a Groovebot developer.
 >>> ~~---------------~~:tools: Commands :tools:~~----------------~~
 **fact** - Retrieves an Animusic fact.
-**neuropol** `[message]` - Parses message into neuropol font. Put a hexcode or `rainbow` at the end of your message to apply color.
+**neuropol** `[message]` - Parses message into neuropol font. Put a hexcode or `#rainbow` at the end of your message to apply color.
 **getalbums** - Retrieves all albums.
 **getabbreviations** - Retrieves all abbreviations.
 **get** `[acronym]` - Retrieves data via acronym.


### PR DESCRIPTION
Was removed in 354e0aade12d53add959766a04de4cd136555a7c, now added back in a cleaner format. 

Thanks @sunset-developer for optimizing! 

Already formatted in Black. 