### PR TITLE
change IBM to Intel

### DIFF
--- a/resources/facts.txt
+++ b/resources/facts.txt
@@ -27,5 +27,5 @@ Future Retro and Pipe Dream are tied for the most hard camera cuts in Animusic 1
 Drum Machine is the only Animusic animation to be composed of a single camera shot.
 The Special Edition of Animusic 1 was released on April 27, 2004.
 Animusic's total DVD sales topped 800,000 worldwide.
-IBM's Pipe Dream project spent over $160,000, and took them 3 months to complete.
+Intel's Pipe Dream project spent over $160,000, and took them 3 months to complete.
 Glarpedge and Super Pipe Dream are the first two songs to have more/less than two words.


### PR DESCRIPTION
IBM did not have any part in the Pipe Dream project.